### PR TITLE
feat: add playwright test support via get playwright-props command (#118385)

### DIFF
--- a/bin/devenv-cli-completion.sh
+++ b/bin/devenv-cli-completion.sh
@@ -106,9 +106,10 @@ _devenv_cli() {
             get)
                 sub_cmd=$(_devenv_is_command $sub_cmd c     config           ||
                           _devenv_is_command $sub_cmd g     geb-props        ||
+                          _devenv_is_command $sub_cmd p     playwright-props ||
                           _devenv_is_command $sub_cmd w     ws-props         ||
                           _devenv_is_command $sub_cmd s     soap-props       ||
-                          _devenv_is_command $sub_cmd b     bash-completion) 
+                          _devenv_is_command $sub_cmd b     bash-completion)
                 ;;
             log)
                 sub_cmd=$(_devenv_is_command $sub_cmd d     dbaccount        ||
@@ -142,7 +143,7 @@ _devenv_cli() {
            \( "$COMP_CWORD" -eq 3 -a ! -z "$property_file" \) ]; then
         case "$cmd" in
             get)
-                COMPREPLY=( $(compgen -W 'config geb-props ws-props soap-props bash-completion -h --help' -- $cur) )
+                COMPREPLY=( $(compgen -W 'config geb-props playwright-props ws-props soap-props bash-completion -h --help' -- $cur) )
                 ;;
             info)
                 COMPREPLY=( $(compgen -W 'iom postgres mailserver cluster config -h --help' -- $cur) )

--- a/bin/devenv-cli.sh
+++ b/bin/devenv-cli.sh
@@ -1152,11 +1152,12 @@ CONFIG-FILE
 $(msg_config_file 4)
 
 RESOURCE
-    config|c*          get configuration file
-    ws-props|w*        get ws properties
-    geb-props|g*       get geb properties
-    soap-props|s*      get soap properties
-    bash-completion|b* get bash completion script
+    config|c*           get configuration file
+    ws-props|w*         get ws properties
+    geb-props|g*        get geb properties
+    playwright-props|p* get playwright properties
+    soap-props|s*       get soap properties
+    bash-completion|b*  get bash completion script
 
 Run '$ME [CONFIG-FILE] get RESOURCE --help|-h' for more information on a command.
 EOF
@@ -1245,6 +1246,30 @@ $(msg_config_file 4)
 BACKGROUND
     "$DEVENV_DIR/bin/template_engine.sh" \\
       --template="$DEVENV_DIR/templates/geb.properties.template" \\
+      --config="$CONFIG_FILES" \\
+      --project-dir="$PROJECT_DIR"
+EOF
+}
+
+#-------------------------------------------------------------------------------
+help-get-playwright-props() {
+    ME=$(basename "$0")
+    cat <<EOF
+writes playwright properties to stdout
+
+SYNOPSIS
+    $ME [CONFIG-FILE] get playwright-props
+
+OVERVIEW
+    Writes playwright properties to stdout. This file is required to run
+    playwright-tests on the managed IOM installation.
+
+CONFIG-FILE
+$(msg_config_file 4)
+
+BACKGROUND
+    "$DEVENV_DIR/bin/template_engine.sh" \\
+      --template="$DEVENV_DIR/templates/playwright.properties.template" \\
       --config="$CONFIG_FILES" \\
       --project-dir="$PROJECT_DIR"
 EOF
@@ -3037,6 +3062,31 @@ get-ws-props() {
 }
 
 #-------------------------------------------------------------------------------
+# get playwright.properties
+#-------------------------------------------------------------------------------
+get-playwright-props() {
+    SUCCESS=true
+
+    if [ -z "$CONFIG_FILES" ]; then
+        log_msg ERROR "get-playwright-props: no config-file given!" < /dev/null
+        SUCCESS=false
+    else
+        "$DEVENV_DIR/bin/template_engine.sh" \
+            --template="$DEVENV_DIR/templates/playwright.properties.template" \
+            --config="$CONFIG_FILES" \
+            --project-dir="$PROJECT_DIR" 2> "$TMP_ERR"
+        if [ $? -ne 0 ]; then
+            log_msg ERROR "get-playwright-props: error writing playwright.properties." < "$TMP_ERR"
+            SUCCESS=false
+        else
+            log_msg INFO "get-playwright-props: playwright.properties successfully written" < /dev/null
+        fi
+    fi
+    rm -f "$TMP_ERR"
+    [ "$SUCCESS" = 'true' ]
+}
+
+#-------------------------------------------------------------------------------
 # get geb.properties
 #-------------------------------------------------------------------------------
 get-geb-props() {
@@ -3702,6 +3752,7 @@ elif [ "$LEVEL0" = "dump" ]; then
 elif [ "$LEVEL0" = 'get' ]; then
     LEVEL1=$(isCommand "$1" c config           ||
              isCommand "$1" g geb-props        ||
+             isCommand "$1" p playwright-props ||
              isCommand "$1" w ws-props         ||
              isCommand "$1" s soap-props       ||
              isCommand "$1" b bash-completion) ||

--- a/doc/05_development_process.md
+++ b/doc/05_development_process.md
@@ -365,6 +365,23 @@ To run a single test, use the feature name or a substring of it. For example:
     # Run a group of Geb tests
     ./gradlew gebTest -Pgeb.propFile=${PATH_TO_GEB_PROPERTIES}/geb.properties --tests="*admin_Oms_1 lists users for role-assignment*"
 
+### Run Playwright Tests
+
+To run Playwright tests, use the property file provided by _devenv-4-iom_:
+
+    # Make sure that playwright.properties reflects the latest version of configuration
+    devenv-cli.sh get playwright-props > playwright.properties
+
+    # Go to the oms.tests directory in your oms source directory
+    # PATH_TO_IOM_SOURCES and PATH_TO_PLAYWRIGHT_PROPERTIES have to be replaced by real values.
+    cd ${PATH_TO_IOM_SOURCES}/oms.tests
+
+    # Run a single Playwright test
+    ./gradlew playwrightTest -Pplaywright.propFile=${PATH_TO_PLAYWRIGHT_PROPERTIES}/playwright.properties --tests="IOM: Role Assignment Management: admin_Oms_1 lists users for role-assignment"
+
+    # Run a group of Playwright tests
+    ./gradlew playwrightTest -Pplaywright.propFile=${PATH_TO_PLAYWRIGHT_PROPERTIES}/playwright.properties --tests="*admin_Oms_1 lists users for role-assignment*"
+
 ### Run Single ws Tests or a Group of ws Tests
 
 To run a single test, use the the feature name or a substring of it. For example:

--- a/templates/playwright.properties.template
+++ b/templates/playwright.properties.template
@@ -1,0 +1,59 @@
+################################################################################
+#
+# IMPORTANT INFORMATION
+#
+# This file is not intended to make any changes on it.
+#
+# This file is generated from a template. With each update of devenv-4-iom it
+# has to be updated. During this process the file is recreated using the
+# information found in config.properties. Any changes you had made before to
+# this file, will be lost.
+#
+# Individual properties can be overridden on the Gradle command line without
+# editing this file, e.g.:
+#
+#   ./gradlew playwrightTest -Pplaywright.propFile=playwright.properties \
+#     -Dplaywright.headless=false --tests="*RoleManagement*"
+#
+################################################################################
+
+# web app
+is.oms.app.host       = ${HostIom}
+is.oms.app.http.port  = ${PORT_IOM_SERVICE}
+is.oms.app.https.port = 443
+
+# Protocol used to connect to the IOM instance. Default: http
+is.oms.app.protocol = http
+
+# db
+is.oms.db.hostlist       = ${PgHostExtern}:${PgPortExtern}
+is.oms.db.name           = ${OMS_DB_NAME}
+is.oms.db.user           = ${OMS_DB_USER}${PGUSER_CONNECTION_SUFFIX}
+is.oms.db.pass           = ${OMS_DB_PASS}
+is.oms.db.serverTimezone = UTC
+
+# standalone application or not
+is.oms.app.standalone = true
+
+# Playwright browser to use. Supported values: firefox, chromium, webkit. Default: firefox
+playwright.browser = firefox
+
+# Run browser in headless mode. Set to false to watch tests run in a visible browser window. Default: true
+playwright.headless = true
+
+# Default timeout in milliseconds for Playwright actions and assertions. Default: 12000
+playwright.timeout = 12000
+
+# Optional: force SSL for the IOM OMT connection. Uncomment to enable.
+# is.oms.omt.forceSsl = true
+
+# Optional: force SSL for the database connection. Uncomment to enable.
+# is.oms.db.forceSsl = true
+
+# Optional: minimum number of imported BCG files expected by tests. Uncomment if required by your test suite.
+# is.oms.db.minimumImportedBCGFiles =
+
+# Optional: path to a custom data registry for test data. Uncomment if your tests require it.
+# is.oms.customisation.dataRegistry =
+
+is.oms.customisation.excludes =

--- a/test/unit/test_template_playwright.sh
+++ b/test/unit/test_template_playwright.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEVENV_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/assert.sh"
+
+PROPS="$SCRIPT_DIR/test.properties.default"
+RENDER="$DEVENV_DIR/bin/template_engine.sh"
+
+echo "=== playwright.properties.template ==="
+
+TEMPLATE="$DEVENV_DIR/templates/playwright.properties.template"
+
+test_case "template renders without error"
+OUTPUT=$("$RENDER" --template="$TEMPLATE" --config="$PROPS" --project-dir="$DEVENV_DIR" 2>&1)
+assert_exit_success "exit code 0" $?
+
+test_case "app host substituted"
+assert_contains "is.oms.app.host present" "$OUTPUT" "is.oms.app.host"
+
+test_case "http port substituted"
+assert_contains "is.oms.app.http.port present" "$OUTPUT" "is.oms.app.http.port"
+
+test_case "db hostlist substituted"
+assert_contains "is.oms.db.hostlist present" "$OUTPUT" "is.oms.db.hostlist"
+
+test_case "db name substituted"
+assert_contains "is.oms.db.name present" "$OUTPUT" "is.oms.db.name"
+
+test_case "db user substituted"
+assert_contains "is.oms.db.user present" "$OUTPUT" "is.oms.db.user"
+
+test_case "db pass substituted"
+assert_contains "is.oms.db.pass present" "$OUTPUT" "is.oms.db.pass"
+
+test_case "no unsubstituted variables"
+assert_not_contains "no raw HostIom" "$OUTPUT" '${HostIom}'
+assert_not_contains "no raw PORT_IOM_SERVICE" "$OUTPUT" '${PORT_IOM_SERVICE}'
+assert_not_contains "no raw PgHostExtern" "$OUTPUT" '${PgHostExtern}'
+assert_not_contains "no raw PgPortExtern" "$OUTPUT" '${PgPortExtern}'
+assert_not_contains "no raw OMS_DB_NAME" "$OUTPUT" '${OMS_DB_NAME}'
+assert_not_contains "no raw OMS_DB_USER" "$OUTPUT" '${OMS_DB_USER}'
+assert_not_contains "no raw OMS_DB_PASS" "$OUTPUT" '${OMS_DB_PASS}'
+
+test_summary


### PR DESCRIPTION
Adds `get playwright-props` subcommand, template, unit test, bash completion, and documentation section mirroring the existing geb-props pattern. The playwright template omits ws/jwt properties (unused by playwright tests) and adds playwright-specific optional properties (browser, headless, timeout) with documented defaults.