### PR TITLE
fix: correct deprecated property handling in config template and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,9 @@ The following configuration variables have been renamed:
 * `CAAS_IMPORT_TEST_DATA` -> `PROJECT_IMPORT_TEST_DATA`
 * `CAAS_IMPORT_TEST_DATA_TIMEOUT` -> `PROJECT_IMPORT_TEST_DATA_TIMEOUT`
 
-Only the names have changed, the meaning of the configuration variables remains unchanged.
+Only the names have changed, the meaning of the configuration variables remains unchanged. The old `CAAS_*` names have been removed.
+
+**Migration:** Follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom). Remove any `CAAS_*` entries from your configuration files and set the corresponding `PROJECT_*` variables instead.
 
 ### Documentation is Part of the Source Repository Now <!-- 71048 -->
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Three new configuration variables replace the single `IMAGE_PULL_POLICY` propert
 
 `IMAGE_PULL_POLICY` is deprecated. It still works as a fallback default for `IMAGE_PULL_POLICY_IOM` and will produce a warning when set. It will be removed in a future version. Replace it with `IMAGE_PULL_POLICY_IOM` in your configuration files.
 
-**Migration:** Replace `IMAGE_PULL_POLICY` with `IMAGE_PULL_POLICY_IOM` in your configuration files and run `get config` to update to the current template. See [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom).
+**Migration:** Replace `IMAGE_PULL_POLICY` with `IMAGE_PULL_POLICY_IOM` in your configuration files. Then follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom).
 
 ### Renamed PostgreSQL Image Property
 
 `DOCKER_DB_IMAGE` has been renamed to `POSTGRES_IMAGE`. The old name is deprecated, still works as a fallback, and will produce a warning when set. It will be removed in a future version.
 
-**Migration:** Replace `DOCKER_DB_IMAGE` with `POSTGRES_IMAGE` in your configuration files and run `get config` to update to the current template. See [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom).
+**Migration:** Replace `DOCKER_DB_IMAGE` with `POSTGRES_IMAGE` in your configuration files. Then follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom).
 
 ### Remote Debugging via `kubectl port-forward`
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The default value of `KUBERNETES_CONTEXT` has changed from `docker-desktop` to `
 
 The previous `KEEP_DATABASE_DATA` flag and Docker-volume-based storage have been replaced by the `POSTGRES_DATA_DIR` property. Set it to a host directory path to persist PostgreSQL data across cluster restarts. Absolute and relative paths are supported; relative paths are resolved against the directory of `devenv.project.properties`, or the current working directory if no project-specific configuration exists. Leave it empty (the default) to run PostgreSQL without persistent storage.
 
-**Migration:** Follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom). Afterwards, set `POSTGRES_DATA_DIR` to a path of your choice, or leave it empty to run without persistent storage. Note that the previous default (`KEEP_DATABASE_DATA=true`) persisted data automatically — the new default does not. If you relied on the old default, set `POSTGRES_DATA_DIR` explicitly to avoid losing database data on pod restart.
+**Migration:** Follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom). Afterwards, set `POSTGRES_DATA_DIR` to a path of your choice, or leave it empty to run without persistent storage. Note that there is no migration path for existing database content — let IOM reinitialise the database on next start.
 
 ### Updated Default PostgreSQL Version
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The default value of `KUBERNETES_CONTEXT` has changed from `docker-desktop` to `
 
 The previous `KEEP_DATABASE_DATA` flag and Docker-volume-based storage have been replaced by the `POSTGRES_DATA_DIR` property. Set it to a host directory path to persist PostgreSQL data across cluster restarts. Absolute and relative paths are supported; relative paths are resolved against the directory of `devenv.project.properties`, or the current working directory if no project-specific configuration exists. Leave it empty (the default) to run PostgreSQL without persistent storage.
 
-**Migration:** Remove `KEEP_DATABASE_DATA` from your configuration file and add `POSTGRES_DATA_DIR` with a path of your choice, or leave it empty to run without persistent storage. Note that the previous default (`KEEP_DATABASE_DATA=true`) persisted data automatically — the new default does not. If you relied on the old default, set `POSTGRES_DATA_DIR` explicitly to avoid losing database data on pod restart.
+**Migration:** Follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom). Afterwards, set `POSTGRES_DATA_DIR` to a path of your choice, or leave it empty to run without persistent storage. Note that the previous default (`KEEP_DATABASE_DATA=true`) persisted data automatically — the new default does not. If you relied on the old default, set `POSTGRES_DATA_DIR` explicitly to avoid losing database data on pod restart.
 
 ### Updated Default PostgreSQL Version
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ The commands `create storage`, `delete storage`, and `info storage`, which manag
 
 The dual-image distribution of IOM (separate `IOM_CONFIG_IMAGE` and `IOM_APP_IMAGE`) that was used before IOM 4.0 is no longer supported. The configuration variables `IOM_CONFIG_IMAGE` and `IOM_APP_IMAGE` have been removed. Use `IOM_IMAGE` to define the IOM image.
 
+### `CAAS_*` Configuration Variables Removed
+
+The `CAAS_ENV_NAME`, `CAAS_IMPORT_TEST_DATA`, and `CAAS_IMPORT_TEST_DATA_TIMEOUT` configuration variables, deprecated since version 2.0.5, have been removed. Use `PROJECT_ENV_NAME`, `PROJECT_IMPORT_TEST_DATA`, and `PROJECT_IMPORT_TEST_DATA_TIMEOUT` instead.
+
 # Release information 2.7.0
 
 ## New Features
@@ -266,9 +270,7 @@ The following configuration variables have been renamed:
 * `CAAS_IMPORT_TEST_DATA` -> `PROJECT_IMPORT_TEST_DATA`
 * `CAAS_IMPORT_TEST_DATA_TIMEOUT` -> `PROJECT_IMPORT_TEST_DATA_TIMEOUT`
 
-Only the names have changed, the meaning of the configuration variables remains unchanged. The old `CAAS_*` names have been removed.
-
-**Migration:** Follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom). Remove any `CAAS_*` entries from your configuration files and set the corresponding `PROJECT_*` variables instead.
+Only the names have changed, the meaning of the configuration variables remains unchanged.
 
 ### Documentation is Part of the Source Repository Now <!-- 71048 -->
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The previous `KEEP_DATABASE_DATA` flag and Docker-volume-based storage have been
 
 ### Updated Default PostgreSQL Version
 
-The default PostgreSQL image has been updated from `postgres:12` (end-of-life since October 2023) to `postgres:17`.
+The default PostgreSQL image has been updated from `postgres:12` (end-of-life since October 2023) to `postgres:18`.
 
 **Migration:** Since the database persistence mechanism has also changed (Docker volumes replaced by `POSTGRES_DATA_DIR`), existing data from previous installations is no longer accessible regardless of the PostgreSQL version. Delete any old Docker volumes and let IOM reinitialise the database on next start.
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Three new configuration variables replace the single `IMAGE_PULL_POLICY` propert
 
 `IMAGE_PULL_POLICY` is deprecated. It still works as a fallback default for `IMAGE_PULL_POLICY_IOM` and will produce a warning when set. It will be removed in a future version. Replace it with `IMAGE_PULL_POLICY_IOM` in your configuration files.
 
-**Migration:** Replace `IMAGE_PULL_POLICY` with `IMAGE_PULL_POLICY_IOM` in your configuration files. Then follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom).
+**Migration:** Follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom). The migration will automatically carry the value of `IMAGE_PULL_POLICY` over to `IMAGE_PULL_POLICY_IOM`.
 
 ### Renamed PostgreSQL Image Property
 
 `DOCKER_DB_IMAGE` has been renamed to `POSTGRES_IMAGE`. The old name is deprecated, still works as a fallback, and will produce a warning when set. It will be removed in a future version.
 
-**Migration:** Replace `DOCKER_DB_IMAGE` with `POSTGRES_IMAGE` in your configuration files. Then follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom).
+**Migration:** Follow the standard procedure to update to the current template: [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom). The migration will automatically carry the value of `DOCKER_DB_IMAGE` over to `POSTGRES_IMAGE`.
 
 ### Remote Debugging via `kubectl port-forward`
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ Three new configuration variables replace the single `IMAGE_PULL_POLICY` propert
 
 `IMAGE_PULL_POLICY` is deprecated. It still works as a fallback default for `IMAGE_PULL_POLICY_IOM` and will produce a warning when set. It will be removed in a future version. Replace it with `IMAGE_PULL_POLICY_IOM` in your configuration files.
 
+**Migration:** Replace `IMAGE_PULL_POLICY` with `IMAGE_PULL_POLICY_IOM` in your configuration files and run `get config` to update to the current template. See [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom).
+
 ### Renamed PostgreSQL Image Property
 
 `DOCKER_DB_IMAGE` has been renamed to `POSTGRES_IMAGE`. The old name is deprecated, still works as a fallback, and will produce a warning when set. It will be removed in a future version.
 
-**Migration:** Replace `DOCKER_DB_IMAGE` with `POSTGRES_IMAGE` in your configuration files.
+**Migration:** Replace `DOCKER_DB_IMAGE` with `POSTGRES_IMAGE` in your configuration files and run `get config` to update to the current template. See [Migrate a Configuration After Updating _devenv-4-iom_](doc/02_configuration.md#migrate-a-configuration-after-updating-devenv-4-iom).
 
 ### Remote Debugging via `kubectl port-forward`
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ a certain version of IOM.
 
 ### Rancher Desktop Support <!-- #117544 -->
 
-[Rancher Desktop](https://rancherdesktop.io/) is now the recommended Kubernetes platform for _devenv-4-iom_. It is open-source, free for commercial use, and correctly exposes host directories into the Kubernetes node on macOS, Linux, and Windows. See [Rancher Desktop setup](doc/10_rancher_desktop.md) for installation and setup instructions.
+[Rancher Desktop](https://rancherdesktop.io/) is now the recommended Kubernetes platform for _devenv-4-iom_. It is open-source and free for commercial use. See [Rancher Desktop setup](doc/10_rancher_desktop.md) for installation and setup instructions.
 
 Docker Desktop continues to be supported. See [Docker Desktop](doc/09_docker_desktop.md) for details on the kubeadm and kind engines.
 

--- a/bin/devenv-cli.sh
+++ b/bin/devenv-cli.sh
@@ -2081,8 +2081,7 @@ Properties:
 $($DEVENV_DIR/bin/template_engine.sh \
     --template="$DEVENV_DIR/templates/config.properties.template" \
     --config="$CONFIG_FILES" \
-    --project-dir="$PROJECT_DIR" | grep -v '^[ \t]*#' | grep -v '^[ \t]*$' \
-    | grep -v '^IMAGE_PULL_POLICY=' | grep -v '^DOCKER_DB_IMAGE=')
+    --project-dir="$PROJECT_DIR" | grep -v '^[ \t]*#' | grep -v '^[ \t]*$')
 --------------------------------------------------------------------------------
 EOF
     fi

--- a/bin/template-variables
+++ b/bin/template-variables
@@ -36,24 +36,19 @@ SSO_OIDC_CONFIG="${SSO_OIDC_CONFIG}"
 
 OTEL_COLLECTOR="${OTEL_COLLECTOR}"
 
-# DEPRECATED: IMAGE_PULL_POLICY is superseded by the per-image variables below.
-# It is kept only as a fallback default for IMAGE_PULL_POLICY_IOM.
-# To remove in a future version: delete the next four lines and the
-# IMAGE_PULL_POLICY block in config.properties.template.
-if [ -n "${IMAGE_PULL_POLICY+set}" ] && type log_msg > /dev/null 2>&1; then
+# DEPRECATED: IMAGE_PULL_POLICY is superseded by IMAGE_PULL_POLICY_IOM.
+# To remove in a future version: delete this block.
+if [ -n "${IMAGE_PULL_POLICY+set}" ]; then
     if [ -n "${IMAGE_PULL_POLICY_IOM+set}" ]; then
-        log_msg WARN "IMAGE_PULL_POLICY is deprecated and ignored because IMAGE_PULL_POLICY_IOM is set. Remove IMAGE_PULL_POLICY from your configuration." < /dev/null
+        type log_msg > /dev/null 2>&1 && log_msg WARN "IMAGE_PULL_POLICY is deprecated and ignored because IMAGE_PULL_POLICY_IOM is set. Remove IMAGE_PULL_POLICY from your configuration." < /dev/null
     else
-        log_msg WARN "IMAGE_PULL_POLICY is deprecated. Use IMAGE_PULL_POLICY_IOM instead. IMAGE_PULL_POLICY_IOM has been set to the value of IMAGE_PULL_POLICY." < /dev/null
+        type log_msg > /dev/null 2>&1 && log_msg WARN "IMAGE_PULL_POLICY is deprecated. Use IMAGE_PULL_POLICY_IOM instead. IMAGE_PULL_POLICY_IOM has been set to the value of IMAGE_PULL_POLICY." < /dev/null
+        IMAGE_PULL_POLICY_IOM="${IMAGE_PULL_POLICY}"
     fi
 fi
-IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-Always}"
 
-# Per-image pull policies. IMAGE_PULL_POLICY_IOM defaults to the global
-# IMAGE_PULL_POLICY for backward compatibility. Postgres and mail server
-# default to IfNotPresent since these are versioned infrastructure images that
-# rarely change on the same tag.
-IMAGE_PULL_POLICY_IOM="${IMAGE_PULL_POLICY_IOM:-$IMAGE_PULL_POLICY}"
+# Per-image pull policies.
+IMAGE_PULL_POLICY_IOM="${IMAGE_PULL_POLICY_IOM:-Always}"
 IMAGE_PULL_POLICY_POSTGRES="${IMAGE_PULL_POLICY_POSTGRES:-IfNotPresent}"
 IMAGE_PULL_POLICY_MAILSRV="${IMAGE_PULL_POLICY_MAILSRV:-IfNotPresent}"
 
@@ -417,16 +412,16 @@ TIMEZONE="${TIMEZONE:-Europe/Berlin}"
 
 # images
 # DEPRECATED: DOCKER_DB_IMAGE is superseded by POSTGRES_IMAGE.
-# To remove in a future version: delete the next five lines and the
-# DOCKER_DB_IMAGE block in config.properties.template.
-if [ -n "${DOCKER_DB_IMAGE+set}" ] && type log_msg > /dev/null 2>&1; then
+# To remove in a future version: delete this block.
+if [ -n "${DOCKER_DB_IMAGE+set}" ]; then
     if [ -n "${POSTGRES_IMAGE+set}" ]; then
-        log_msg WARN "DOCKER_DB_IMAGE is deprecated and ignored because POSTGRES_IMAGE is set. Remove DOCKER_DB_IMAGE from your configuration." < /dev/null
+        type log_msg > /dev/null 2>&1 && log_msg WARN "DOCKER_DB_IMAGE is deprecated and ignored because POSTGRES_IMAGE is set. Remove DOCKER_DB_IMAGE from your configuration." < /dev/null
     else
-        log_msg WARN "DOCKER_DB_IMAGE is deprecated. Use POSTGRES_IMAGE instead. POSTGRES_IMAGE has been set to the value of DOCKER_DB_IMAGE." < /dev/null
+        type log_msg > /dev/null 2>&1 && log_msg WARN "DOCKER_DB_IMAGE is deprecated. Use POSTGRES_IMAGE instead. POSTGRES_IMAGE has been set to the value of DOCKER_DB_IMAGE." < /dev/null
+        POSTGRES_IMAGE="${DOCKER_DB_IMAGE}"
     fi
 fi
-POSTGRES_IMAGE="${POSTGRES_IMAGE:-${DOCKER_DB_IMAGE:-postgres:18}}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:18}"
 
 # postgres 18+ requires the mount at /var/lib/postgresql (it places data in a
 # versioned subdirectory underneath). Earlier versions write directly into

--- a/bin/template-variables
+++ b/bin/template-variables
@@ -14,21 +14,7 @@ KUBERNETES_CONTEXT="${KUBERNETES_CONTEXT:-rancher-desktop}"
 INDEX="${INDEX:-0}"
 PORT_OFFSET="${PORT_OFFSET:-10}"
 
-# environment specific configuration defaults to 'ci'
-# TODO remove if-block after deprecation period
-if [ -z "$PROJECT_ENV_NAME" -a ! -z "$CAAS_ENV_NAME" ]; then
-    PROJECT_ENV_NAME="$CAAS_ENV_NAME"
-fi
 PROJECT_ENV_NAME="${PROJECT_ENV_NAME:-ci}"
-
-# import of test-data
-# TODO remove if-blocks after deprecation period
-if [ -z "$PROJECT_IMPORT_TEST_DATA" -a ! -z "$CAAS_IMPORT_TEST_DATA" ]; then
-    PROJECT_IMPORT_TEST_DATA="$CAAS_IMPORT_TEST_DATA"
-fi
-if [ -z "$PROJECT_IMPORT_TEST_DATA_TIMEOUT" -a ! -z "$CAAS_IMPORT_TEST_DATA_TIMEOUT" ]; then
-    PROJECT_IMPORT_TEST_DATA_TIMEOUT="$CAAS_IMPORT_TEST_DATA_TIMEOUT"
-fi
 PROJECT_IMPORT_TEST_DATA="${PROJECT_IMPORT_TEST_DATA:-true}"
 PROJECT_IMPORT_TEST_DATA_TIMEOUT="${PROJECT_IMPORT_TEST_DATA_TIMEOUT:-300}"
 

--- a/doc/01_first_steps.md
+++ b/doc/01_first_steps.md
@@ -46,7 +46,7 @@ Open the newly created config-file _devenv.project.properties_ and use the value
     docker login docker.tools.intershop.com
 
     # pull images from registry
-    docker pull postgres:17
+    docker pull postgres:18
     docker pull axllent/mailpit
     docker pull docker.tools.intershop.com/iom/intershophub/iom-dbaccount:1.5.0
     docker pull docker.tools.intershop.com/iom/intershophub/iom:4.1.0
@@ -76,7 +76,7 @@ Due to the quite complex configuration of _devenv-4-iom_, see [Configuration | G
     KUBERNETES_CONTEXT=rancher-desktop
     IMAGE_PULL_POLICY_IOM=IfNotPresent
     IMAGE_PULL_SECRET=
-    POSTGRES_IMAGE=postgres:17
+    POSTGRES_IMAGE=postgres:18
     MAILSRV_IMAGE=axllent/mailpit
     IOM_DBACCOUNT_IMAGE=docker.tools.intershop.com/iom/intershophub/iom-dbaccount:1.5.0
     IOM_IMAGE=docker.tools.intershop.com/iom/intershophub/iom:4.1.0

--- a/templates/config.properties.template
+++ b/templates/config.properties.template
@@ -33,17 +33,8 @@ KUBERNETES_CONTEXT="${KUBERNETES_CONTEXT}"
 # Docker Image Settings
 ################################################################################
 
-# IMAGE_PULL_POLICY is the default pull policy for IOM images (IOM app,
-# dbaccount, and all IOM job images). If left empty, it defaults to "Always",
-# which makes development easy, as always the newest version of the requested
-# Docker image will be used. It can be set to any value allowed by
-# ImagePullPolicy.
-# See https://kubernetes.io/docs/concepts/configuration/overview/#container-images
-IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY}
-
-# Per-image pull policies. When set, these override IMAGE_PULL_POLICY for the
-# respective image group. Leave empty to inherit from IMAGE_PULL_POLICY (IOM)
-# or use the built-in default of IfNotPresent (postgres, mail server).
+# Per-image pull policies. Leave empty to use the built-in default of
+# IfNotPresent (postgres, mail server) or Always (IOM).
 IMAGE_PULL_POLICY_IOM=${IMAGE_PULL_POLICY_IOM}
 IMAGE_PULL_POLICY_POSTGRES=${IMAGE_PULL_POLICY_POSTGRES}
 IMAGE_PULL_POLICY_MAILSRV=${IMAGE_PULL_POLICY_MAILSRV}
@@ -68,11 +59,6 @@ IMAGE_PULL_SECRET=${IMAGE_PULL_SECRET}
 # which is not supported by devenv-4-iom. Delete the contents of
 # POSTGRES_DATA_DIR before switching and let IOM reinitialise the database.
 POSTGRES_IMAGE=${POSTGRES_IMAGE}
-
-# DEPRECATED: DOCKER_DB_IMAGE is superseded by POSTGRES_IMAGE.
-# It is kept for backward compatibility and will be removed in a future version.
-# Replace DOCKER_DB_IMAGE with POSTGRES_IMAGE in your configuration file.
-DOCKER_DB_IMAGE=${DOCKER_DB_IMAGE}
 
 # mail-server image (name:tag)
 # example:                  axllent/mailpit

--- a/test/unit/test.properties.default
+++ b/test/unit/test.properties.default
@@ -1,6 +1,6 @@
 ID=test
 IMAGE_PULL_POLICY_IOM=IfNotPresent
-POSTGRES_IMAGE=postgres:17
+POSTGRES_IMAGE=postgres:18
 MAILSRV_IMAGE=axllent/mailpit
 IOM_DBACCOUNT_IMAGE=iom-dbaccount:1.5.0
 IOM_IMAGE=ci-iom:5.1.0-1.0.0-SNAPSHOT

--- a/test/unit/test_deprecated_properties.sh
+++ b/test/unit/test_deprecated_properties.sh
@@ -101,30 +101,6 @@ assert_contains "IMAGE_PULL_POLICY_IOM set to migrated value" "$OUTPUT" "IMAGE_P
 test_case "IMAGE_PULL_POLICY in input: IMAGE_PULL_POLICY does not appear in output"
 assert_not_contains "no IMAGE_PULL_POLICY= line in output" "$OUTPUT" "IMAGE_PULL_POLICY=Never"
 
-test_case "CAAS_ENV_NAME in input: PROJECT_ENV_NAME carries its value in output"
-echo "CAAS_ENV_NAME=staging" > "$TMPDIR_MIGRATION/old_caas.properties"
-OUTPUT=$("$RENDER" \
-    --template="$CONFIG_TEMPLATE" \
-    --config="$TMPDIR_MIGRATION/old_caas.properties" \
-    --project-dir="$DEVENV_DIR" 2>/dev/null)
-assert_contains "PROJECT_ENV_NAME set to migrated value" "$OUTPUT" "PROJECT_ENV_NAME=staging"
-
-test_case "CAAS_IMPORT_TEST_DATA in input: PROJECT_IMPORT_TEST_DATA carries its value in output"
-echo "CAAS_IMPORT_TEST_DATA=false" > "$TMPDIR_MIGRATION/old_caas2.properties"
-OUTPUT=$("$RENDER" \
-    --template="$CONFIG_TEMPLATE" \
-    --config="$TMPDIR_MIGRATION/old_caas2.properties" \
-    --project-dir="$DEVENV_DIR" 2>/dev/null)
-assert_contains "PROJECT_IMPORT_TEST_DATA set to migrated value" "$OUTPUT" "PROJECT_IMPORT_TEST_DATA=false"
-
-test_case "CAAS_IMPORT_TEST_DATA_TIMEOUT in input: PROJECT_IMPORT_TEST_DATA_TIMEOUT carries its value in output"
-echo "CAAS_IMPORT_TEST_DATA_TIMEOUT=600" > "$TMPDIR_MIGRATION/old_caas3.properties"
-OUTPUT=$("$RENDER" \
-    --template="$CONFIG_TEMPLATE" \
-    --config="$TMPDIR_MIGRATION/old_caas3.properties" \
-    --project-dir="$DEVENV_DIR" 2>/dev/null)
-assert_contains "PROJECT_IMPORT_TEST_DATA_TIMEOUT set to migrated value" "$OUTPUT" "PROJECT_IMPORT_TEST_DATA_TIMEOUT=600"
-
 rm -rf "$TMPDIR_MIGRATION"
 
 test_summary

--- a/test/unit/test_deprecated_properties.sh
+++ b/test/unit/test_deprecated_properties.sh
@@ -66,4 +66,65 @@ assert_contains "warning mentions IMAGE_PULL_POLICY" "$WARNINGS" "IMAGE_PULL_POL
 assert_contains "warning says ignored" "$WARNINGS" "ignored because IMAGE_PULL_POLICY_IOM is set"
 
 rm -f /tmp/test_deprecated_warnings
+
+# ---------------------------------------------------------------------------
+# get config migration: deprecated properties must not appear in the output
+# of `get config`, while their replacements must carry the migrated value.
+# ---------------------------------------------------------------------------
+
+RENDER="$DEVENV_DIR/bin/template_engine.sh"
+CONFIG_TEMPLATE="$DEVENV_DIR/templates/config.properties.template"
+TMPDIR_MIGRATION="$(mktemp -d)"
+
+echo ""
+echo "=== get config migration ==="
+
+test_case "DOCKER_DB_IMAGE in input: POSTGRES_IMAGE carries its value in output"
+echo "DOCKER_DB_IMAGE=postgres:16" > "$TMPDIR_MIGRATION/old.properties"
+OUTPUT=$("$RENDER" \
+    --template="$CONFIG_TEMPLATE" \
+    --config="$TMPDIR_MIGRATION/old.properties" \
+    --project-dir="$DEVENV_DIR" 2>/dev/null)
+assert_contains "POSTGRES_IMAGE set to migrated value" "$OUTPUT" "POSTGRES_IMAGE=postgres:16"
+
+test_case "DOCKER_DB_IMAGE in input: DOCKER_DB_IMAGE does not appear in output"
+assert_not_contains "no DOCKER_DB_IMAGE line in output" "$OUTPUT" "DOCKER_DB_IMAGE="
+
+test_case "IMAGE_PULL_POLICY in input: IMAGE_PULL_POLICY_IOM carries its value in output"
+echo "IMAGE_PULL_POLICY=Never" > "$TMPDIR_MIGRATION/old_pull.properties"
+OUTPUT=$("$RENDER" \
+    --template="$CONFIG_TEMPLATE" \
+    --config="$TMPDIR_MIGRATION/old_pull.properties" \
+    --project-dir="$DEVENV_DIR" 2>/dev/null)
+assert_contains "IMAGE_PULL_POLICY_IOM set to migrated value" "$OUTPUT" "IMAGE_PULL_POLICY_IOM=Never"
+
+test_case "IMAGE_PULL_POLICY in input: IMAGE_PULL_POLICY does not appear in output"
+assert_not_contains "no IMAGE_PULL_POLICY= line in output" "$OUTPUT" "IMAGE_PULL_POLICY=Never"
+
+test_case "CAAS_ENV_NAME in input: PROJECT_ENV_NAME carries its value in output"
+echo "CAAS_ENV_NAME=staging" > "$TMPDIR_MIGRATION/old_caas.properties"
+OUTPUT=$("$RENDER" \
+    --template="$CONFIG_TEMPLATE" \
+    --config="$TMPDIR_MIGRATION/old_caas.properties" \
+    --project-dir="$DEVENV_DIR" 2>/dev/null)
+assert_contains "PROJECT_ENV_NAME set to migrated value" "$OUTPUT" "PROJECT_ENV_NAME=staging"
+
+test_case "CAAS_IMPORT_TEST_DATA in input: PROJECT_IMPORT_TEST_DATA carries its value in output"
+echo "CAAS_IMPORT_TEST_DATA=false" > "$TMPDIR_MIGRATION/old_caas2.properties"
+OUTPUT=$("$RENDER" \
+    --template="$CONFIG_TEMPLATE" \
+    --config="$TMPDIR_MIGRATION/old_caas2.properties" \
+    --project-dir="$DEVENV_DIR" 2>/dev/null)
+assert_contains "PROJECT_IMPORT_TEST_DATA set to migrated value" "$OUTPUT" "PROJECT_IMPORT_TEST_DATA=false"
+
+test_case "CAAS_IMPORT_TEST_DATA_TIMEOUT in input: PROJECT_IMPORT_TEST_DATA_TIMEOUT carries its value in output"
+echo "CAAS_IMPORT_TEST_DATA_TIMEOUT=600" > "$TMPDIR_MIGRATION/old_caas3.properties"
+OUTPUT=$("$RENDER" \
+    --template="$CONFIG_TEMPLATE" \
+    --config="$TMPDIR_MIGRATION/old_caas3.properties" \
+    --project-dir="$DEVENV_DIR" 2>/dev/null)
+assert_contains "PROJECT_IMPORT_TEST_DATA_TIMEOUT set to migrated value" "$OUTPUT" "PROJECT_IMPORT_TEST_DATA_TIMEOUT=600"
+
+rm -rf "$TMPDIR_MIGRATION"
+
 test_summary

--- a/test/unit/test_deprecated_properties.sh
+++ b/test/unit/test_deprecated_properties.sh
@@ -76,12 +76,19 @@ RENDER="$DEVENV_DIR/bin/template_engine.sh"
 CONFIG_TEMPLATE="$DEVENV_DIR/templates/config.properties.template"
 TMPDIR_MIGRATION="$(mktemp -d)"
 
+# Run the template engine in a clean environment to prevent host environment
+# variables from overriding values read from the config file.
+render_clean() {
+    env -i PATH="$PATH" HOME="$HOME" \
+        "$RENDER" "$@"
+}
+
 echo ""
 echo "=== get config migration ==="
 
 test_case "DOCKER_DB_IMAGE in input: POSTGRES_IMAGE carries its value in output"
 echo "DOCKER_DB_IMAGE=postgres:16" > "$TMPDIR_MIGRATION/old.properties"
-OUTPUT=$("$RENDER" \
+OUTPUT=$(render_clean \
     --template="$CONFIG_TEMPLATE" \
     --config="$TMPDIR_MIGRATION/old.properties" \
     --project-dir="$DEVENV_DIR" 2>/dev/null)
@@ -92,7 +99,7 @@ assert_not_contains "no DOCKER_DB_IMAGE line in output" "$OUTPUT" "DOCKER_DB_IMA
 
 test_case "IMAGE_PULL_POLICY in input: IMAGE_PULL_POLICY_IOM carries its value in output"
 echo "IMAGE_PULL_POLICY=Never" > "$TMPDIR_MIGRATION/old_pull.properties"
-OUTPUT=$("$RENDER" \
+OUTPUT=$(render_clean \
     --template="$CONFIG_TEMPLATE" \
     --config="$TMPDIR_MIGRATION/old_pull.properties" \
     --project-dir="$DEVENV_DIR" 2>/dev/null)

--- a/test/unit/test_template_postgres.sh
+++ b/test/unit/test_template_postgres.sh
@@ -15,7 +15,7 @@ OUTPUT=$("$RENDER" --template="$TEMPLATE" --config="$PROPS" --project-dir="$DEVE
 assert_exit_success "exit code 0" $?
 
 test_case "uses configured postgres image"
-assert_contains "postgres image substituted" "$OUTPUT" "image: postgres:17"
+assert_contains "postgres image substituted" "$OUTPUT" "image: postgres:18"
 
 test_case "hostPath volume present (POSTGRES_DATA_DIR set)"
 assert_contains "hostPath volume defined" "$OUTPUT" "hostPath:"
@@ -27,7 +27,7 @@ assert_not_contains "no PVC kind line" "$OUTPUT" "kind: PersistentVolumeClaim"
 assert_not_contains "no storageClassName" "$OUTPUT" "storageClassName:"
 
 test_case "volume mount present"
-assert_contains "volume mount included" "$OUTPUT" "mountPath: /var/lib/postgresql/data"
+assert_contains "volume mount included" "$OUTPUT" "mountPath: /var/lib/postgresql"
 
 test_case "no unsubstituted PostgresMountPath"
 assert_not_contains "no raw PostgresMountPath" "$OUTPUT" '${PostgresMountPath}'
@@ -59,7 +59,7 @@ rm -rf "$TMPDIR_REL"
 test_case "no POSTGRES_DATA_DIR: hostPath volume commented out"
 OUTPUT_NODATA=$("$RENDER" --template="$TEMPLATE" --config=/dev/null --project-dir="$DEVENV_DIR" 2>&1)
 assert_not_contains "no hostPath when unset" "$OUTPUT_NODATA" "hostPath:"
-assert_not_contains "no volumeMount when unset" "$OUTPUT_NODATA" "mountPath: /var/lib/postgresql/data"
+assert_not_contains "no volumeMount when unset" "$OUTPUT_NODATA" "mountPath: /var/lib/postgresql"
 
 # postgres 18+: mount point moves up one level
 test_case "postgres:18 uses /var/lib/postgresql as mountPath"
@@ -71,8 +71,9 @@ assert_contains "pg18 mountPath is /var/lib/postgresql" "$OUTPUT_PG18" "mountPat
 assert_not_contains "pg18 mountPath has no /data suffix" "$OUTPUT_PG18" "mountPath: /var/lib/postgresql/data"
 rm -rf "$TMPDIR_PG18"
 
-test_case "postgres:17 uses /var/lib/postgresql/data as mountPath"
-assert_contains "pg17 mountPath is /var/lib/postgresql/data" "$OUTPUT" "mountPath: /var/lib/postgresql/data"
+test_case "postgres:18 (default) uses /var/lib/postgresql as mountPath"
+assert_contains "pg18 default mountPath is /var/lib/postgresql" "$OUTPUT" "mountPath: /var/lib/postgresql"
+assert_not_contains "pg18 default mountPath has no /data suffix" "$OUTPUT" "mountPath: /var/lib/postgresql/data"
 
 test_case "non-numeric tag (latest) causes error and non-zero exit"
 TMPDIR_LATEST="$(mktemp -d)"


### PR DESCRIPTION
  ## Summary
  
  - Removes `IMAGE_PULL_POLICY` and `DOCKER_DB_IMAGE` from `config.properties.template`
    so that `get config` no longer writes deprecated properties into migrated config files
  - Drops the compensating `grep -v` filters from `info-config` in `devenv-cli.sh`
  - Removes `CAAS_*` property compatibility shims from `template-variables` (deprecated
    since 2.0.5, now removed); documents removal as a breaking change in the 3.0.0
    release notes, restoring the original 2.0.5 notes unchanged
  - Restructures remaining deprecated property blocks (`IMAGE_PULL_POLICY`,
    `DOCKER_DB_IMAGE`) to be self-contained — the migration logic is inside the block and
    the active assignment after it uses a plain default, so deleting the block is the only
    step needed to remove a deprecated property in the future
  - Updates migration notes in README to reference the standard migration procedure in
    `doc/02_configuration.md` instead of describing incorrect manual steps
  - Updates default PostgreSQL version from `postgres:17` to `postgres:18` in docs,
    test fixture, and test assertions
  - Adds unit tests covering deprecated property warning behaviour and `get config`
    migration output; fixes test environment isolation so CI environment variables
    cannot interfere with migration test results

  ## Test plan
  
  - [ ] Run `test/run-unit-tests.sh` — all tests pass
  - [ ] Run `get config` with a config containing `DOCKER_DB_IMAGE=postgres:16` — output
    contains `POSTGRES_IMAGE=postgres:16`, no `DOCKER_DB_IMAGE=` line
  - [ ] Run `get config` with a config containing `IMAGE_PULL_POLICY=Never` — output
    contains `IMAGE_PULL_POLICY_IOM=Never`, no `IMAGE_PULL_POLICY=Never` line
  - [ ] Setting a deprecated property produces a warning on stderr

  🤖 Generated with [Claude Code](https://claude.com/claude-code)