### PR TITLE
feat/debug support (#119104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The IOM deployment has been changed from a `Deployment` to a `StatefulSet`. This
 
 ### debug port
 `devenv-cli.sh info iom` now displays the command to forward the debug port to the localhost. E.g.:
+
 `Forward debug port:         kubectl port-forward --namespace trunklok --context="rancher-desktop" pod/iom-0 8787:8787 &`
 
 ### New Property `OMS_CUSTOM_SECRET_CONFIG` for IOM 6.1

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ you are currently using. To do so, please update _devenv-4-iom_ as often as poss
 There exists no backward compatibility the other way around. There is no information available, which version of _devenv-4-iom_ is required by
 a certain version of IOM.
 
+# Release information 3.1.0
+
+## New Features
+
+### Stable Pod Name via StatefulSet
+
+The IOM deployment has been changed from a `Deployment` to a `StatefulSet`. This gives the IOM pod a stable, predictable name (e.g. `iom-0`) that does not change across restarts, which is useful for scripting, port-forwarding, and log access.
+
+### debug port
+`devenv-cli.sh info iom` now displays the command to forward the debug port to the localhost. E.g.:
+`Forward debug port:         kubectl port-forward --namespace trunklok --context="rancher-desktop" pod/iom-0 8787:8787 &`
+
+### New Property `OMS_CUSTOM_SECRET_CONFIG` for IOM 6.1
+
+The new configuration variable `OMS_CUSTOM_SECRET_CONFIG` has been added to support the secret-based custom configuration introduced in IOM 6.1. It holds sensitive project configuration — for example, values mapped from a Kubernetes secret — and makes them available to the IOM application at runtime.
+
+
 # Release information 3.0.0
 
 ## New Features

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ The IOM deployment has been changed from a `Deployment` to a `StatefulSet`. This
 
 `Forward debug port:         kubectl port-forward --namespace trunklok --context="rancher-desktop" pod/iom-0 8787:8787 &`
 
-### New Property `CUSTOM_CREDENTIALS_CONFIG` for IOM 6.1
+### New Property `CUSTOM_CREDENTIALS` for IOM 6.1
 
-The new configuration variable `CUSTOM_CREDENTIALS_CONFIG` has been added to support the secret-based custom configuration introduced in IOM 6.1. It holds sensitive project configuration — for example, values mapped from a Kubernetes secret — and makes them available to the IOM application at runtime.
+The new configuration variable `CUSTOM_CREDENTIALS` has been added to support the secret-based custom configuration introduced in IOM 6.1. It holds sensitive project configuration — for example, values mapped from a Kubernetes secret — and makes them available to the IOM application at runtime.
 
 
 # Release information 3.0.0

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ The IOM deployment has been changed from a `Deployment` to a `StatefulSet`. This
 
 `Forward debug port:         kubectl port-forward --namespace trunklok --context="rancher-desktop" pod/iom-0 8787:8787 &`
 
-### New Property `OMS_CUSTOM_SECRET_CONFIG` for IOM 6.1
+### New Property `CUSTOM_CREDENTIALS_CONFIG` for IOM 6.1
 
-The new configuration variable `OMS_CUSTOM_SECRET_CONFIG` has been added to support the secret-based custom configuration introduced in IOM 6.1. It holds sensitive project configuration — for example, values mapped from a Kubernetes secret — and makes them available to the IOM application at runtime.
+The new configuration variable `CUSTOM_CREDENTIALS_CONFIG` has been added to support the secret-based custom configuration introduced in IOM 6.1. It holds sensitive project configuration — for example, values mapped from a Kubernetes secret — and makes them available to the IOM application at runtime.
 
 
 # Release information 3.0.0

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The IOM deployment has been changed from a `Deployment` to a `StatefulSet`. This
 ### debug port
 `devenv-cli.sh info iom` now displays the command to forward the debug port to the localhost. E.g.:
 
-`Forward debug port:         kubectl port-forward --namespace trunklok --context="rancher-desktop" pod/iom-0 8787:8787 &`
+`Forward debug port:         kubectl port-forward --namespace trunklok --context="rancher-desktop" pod/iom-0 8787:8787`
 
 ### New Property `CUSTOM_CREDENTIALS` for IOM 6.1
 

--- a/bin/devenv-cli.sh
+++ b/bin/devenv-cli.sh
@@ -1859,6 +1859,7 @@ Usefull commands:
 
 Login into Pod:             kubectl exec --namespace $EnvId $POD --context="$KUBERNETES_CONTEXT" -c iom -it -- bash
 jboss-cli:                  kubectl exec --namespace $EnvId $POD --context="$KUBERNETES_CONTEXT" -c iom -it -- /opt/jboss/wildfly/bin/jboss-cli.sh -c
+Forward debug port:         kubectl port-forward --namespace $EnvId --context="$KUBERNETES_CONTEXT" pod/$POD 8787:8787 &
 
 Currently used yaml:        kubectl get pod -l app=iom -o yaml --namespace=$EnvId --context="$KUBERNETES_CONTEXT"
 Describe iom pod:           kubectl describe --namespace $EnvId --context="$KUBERNETES_CONTEXT" pod $POD

--- a/bin/template-variables
+++ b/bin/template-variables
@@ -1,4 +1,4 @@
-DEVENV4IOM_VERSION=3.0.1-SNAPSHOT
+DEVENV4IOM_VERSION=3.1.0-SNAPSHOT
 
 ################################################################################
 # Defaults
@@ -343,6 +343,10 @@ SMTP_PORT="${SMTP_PORT}"
 SMTP_USER="${SMTP_USER}"
 SMTP_PASSWORD="${SMTP_PASSWORD}"
 SMTP_ENCRYPTION="${SMTP_ENCRYPTION:-auto}"
+
+# custom secret configuration, injected as JSON into env variable
+# OMS_CUSTOM_SECRET. Empty by default.
+OMS_CUSTOM_SECRET="${OMS_CUSTOM_SECRET}"
 
 if [ "$SMTP_HOST" = 'mailsrv-service' ]; then
     SMTP_HOST=

--- a/bin/template-variables
+++ b/bin/template-variables
@@ -345,8 +345,8 @@ SMTP_PASSWORD="${SMTP_PASSWORD}"
 SMTP_ENCRYPTION="${SMTP_ENCRYPTION:-auto}"
 
 # custom secret configuration, injected as JSON into env variable
-# OMS_CUSTOM_SECRET. Empty by default.
-OMS_CUSTOM_SECRET="${OMS_CUSTOM_SECRET}"
+# CUSTOM_CREDENTIALS. Empty by default.
+CUSTOM_CREDENTIALS="${CUSTOM_CREDENTIALS}"
 
 if [ "$SMTP_HOST" = 'mailsrv-service' ]; then
     SMTP_HOST=

--- a/bin/template-variables
+++ b/bin/template-variables
@@ -344,10 +344,6 @@ SMTP_USER="${SMTP_USER}"
 SMTP_PASSWORD="${SMTP_PASSWORD}"
 SMTP_ENCRYPTION="${SMTP_ENCRYPTION:-auto}"
 
-# custom secret configuration, injected as JSON into env variable
-# CUSTOM_CREDENTIALS. Empty by default.
-CUSTOM_CREDENTIALS="${CUSTOM_CREDENTIALS}"
-
 if [ "$SMTP_HOST" = 'mailsrv-service' ]; then
     SMTP_HOST=
 fi

--- a/doc/05_development_process.md
+++ b/doc/05_development_process.md
@@ -206,15 +206,15 @@ The IOM application server starts with the Java debug agent (JDWP) listening on 
 
 To attach a debugger, use `kubectl port-forward` on demand. Example:
 
-    # Forward the JDWP port to localhost in the background.
+    # Forward the JDWP port to localhost a separate terminal.
     # The IOM pod name is stable ('iom-0') because IOM runs as a StatefulSet.
     kubectl port-forward \
       --namespace iomdevelop \
       --context="rancher-desktop" \
       pod/iom-0 \
-      8787:8787 &
+      8787:8787
 
-Then configure your IDE to connect to `localhost:8787` using a standard remote JVM debug configuration. With &, The port-forward runs in the background. It terminates when you close your console, or manually, with `kill %1` (or the appropriate job number) when the debug session is over.
+Then configure your IDE to connect to `localhost:8787` using a standard remote JVM debug configuration.
 
 The exact `kubectl` invocation (with the correct namespace and context for your environment) is shown by:
 

--- a/doc/05_development_process.md
+++ b/doc/05_development_process.md
@@ -143,11 +143,11 @@ Before creating a new project image, the properties and _Wildfly-CLI_ scripts ha
     # determine command, how to access jboss-cli.sh in running IOM pod
     devenv-cli.sh info iom
     ...
-    jboss-cli: kubectl exec --namespace customerprojectiom410 --context="docker-desktop" iom-7b99d8c9df-trctc -c iom -it -- /opt/jboss/wildfly/bin/jboss-cli.sh -c
+    jboss-cli: kubectl exec --namespace customerprojectiom410 --context="docker-desktop" iom-0 -c iom -it -- /opt/jboss/wildfly/bin/jboss-cli.sh -c
     ...
 
     # execute jboss-cli.sh in running IOM pod
-    kubectl exec --namespace customerprojectiom410 --context="docker-desktop" iom-7b99d8c9df-trctc -c iom -it -- /opt/jboss/wildfly/bin/jboss-cli.sh -c
+    kubectl exec --namespace customerprojectiom410 --context="docker-desktop" iom-0 -c iom -it -- /opt/jboss/wildfly/bin/jboss-cli.sh -c
 
     # test your CLI commands
     [standalone@localhost:9990 /] ls -l /deployment
@@ -204,19 +204,19 @@ _You must not set `CUSTOM_DUMPS_DIR` to a directory that does not contain a dump
 
 The IOM application server starts with the Java debug agent (JDWP) listening on port `${PORT_DEBUG}` (default: `8787`). This port is **not** exposed through the LoadBalancer service — doing so would cause k3s's built-in ServiceLB to probe the JDWP port with plain TCP connections, which the JVM logs as spurious "Debugger failed to attach" warnings.
 
-To attach a debugger, use `kubectl port-forward` on demand:
+To attach a debugger, use `kubectl port-forward` on demand. Example:
 
     # Forward the JDWP port to localhost for the duration of the debug session.
-    # Replace the pod name with the actual name shown by 'devenv-cli.sh info iom'.
+    # The IOM pod name is stable ('iom-0') because IOM runs as a StatefulSet.
     kubectl port-forward \
       --namespace iomdevelop \
       --context="rancher-desktop" \
-      pod/<iom-pod-name> \
-      8787:${PORT_DEBUG}
+      pod/iom-0 \
+      8787:8787
 
 Then configure your IDE to connect to `localhost:8787` using a standard remote JVM debug configuration. The port-forward stays active until you terminate it with Ctrl-C.
 
-The actual pod name and the correct `kubectl` invocation are shown by:
+The exact `kubectl` invocation is shown by:
 
     devenv-cli.sh info iom
 

--- a/doc/05_development_process.md
+++ b/doc/05_development_process.md
@@ -206,17 +206,17 @@ The IOM application server starts with the Java debug agent (JDWP) listening on 
 
 To attach a debugger, use `kubectl port-forward` on demand. Example:
 
-    # Forward the JDWP port to localhost for the duration of the debug session.
+    # Forward the JDWP port to localhost in the background.
     # The IOM pod name is stable ('iom-0') because IOM runs as a StatefulSet.
     kubectl port-forward \
       --namespace iomdevelop \
       --context="rancher-desktop" \
       pod/iom-0 \
-      8787:8787
+      8787:8787 &
 
-Then configure your IDE to connect to `localhost:8787` using a standard remote JVM debug configuration. The port-forward stays active until you terminate it with Ctrl-C.
+Then configure your IDE to connect to `localhost:8787` using a standard remote JVM debug configuration. With &, The port-forward runs in the background. It terminates when you close your console, or manually, with `kill %1` (or the appropriate job number) when the debug session is over.
 
-The exact `kubectl` invocation is shown by:
+The exact `kubectl` invocation (with the correct namespace and context for your environment) is shown by:
 
     devenv-cli.sh info iom
 

--- a/templates/config.properties.template
+++ b/templates/config.properties.template
@@ -93,9 +93,9 @@ SMTP_PASSWORD='${SMTP_PASSWORD}'
 SMTP_ENCRYPTION=${SMTP_ENCRYPTION}
 
 
-################################################################################
-# custom secret configuration, injected as JSON into an environment variable
-################################################################################
+##################################################################################
+# project credentials configuration, injected as JSON into an environment variable
+##################################################################################
 CUSTOM_CREDENTIALS="${CUSTOM_CREDENTIALS}"
 
 

--- a/templates/config.properties.template
+++ b/templates/config.properties.template
@@ -96,7 +96,7 @@ SMTP_ENCRYPTION=${SMTP_ENCRYPTION}
 ################################################################################
 # custom secret configuration, injected as JSON into an environment variable
 ################################################################################
-OMS_CUSTOM_SECRET="${OMS_CUSTOM_SECRET}"
+CUSTOM_CREDENTIALS="${CUSTOM_CREDENTIALS}"
 
 
 ################################################################################

--- a/templates/config.properties.template
+++ b/templates/config.properties.template
@@ -92,6 +92,13 @@ SMTP_PASSWORD='${SMTP_PASSWORD}'
 # allowed values are 'auto', 'ssl', 'startTls'
 SMTP_ENCRYPTION=${SMTP_ENCRYPTION}
 
+
+################################################################################
+# custom secret configuration, injected as JSON into an environment variable
+################################################################################
+OMS_CUSTOM_SECRET="${OMS_CUSTOM_SECRET}"
+
+
 ################################################################################
 # Database Configuration
 ################################################################################

--- a/templates/iom.yml.template
+++ b/templates/iom.yml.template
@@ -1,10 +1,11 @@
-kind: Deployment
+kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: iom
   labels:
     app: iom
 spec:
+  serviceName: iom-headless
   replicas: 1
   selector:
     matchLabels:
@@ -199,6 +200,22 @@ ${DumpsDirYml____}          mountPath: /opt/oms/dumps
               value: "${OMS_DB_SEARCHPATH}"
             - name: OMS_LOGLEVEL_SCRIPTS
               value: '${OMS_LOGLEVEL_SCRIPTS}'
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: iom-headless
+spec:
+  clusterIP: None
+  selector:
+    app: iom
+  ports:
+    - name: http
+      port: ${PORT_IOM_SERVICE}
+      targetPort: ${PORT_IOM}
+    - name: admin
+      port: ${PORT_WILDFLY_SERVICE}
+      targetPort: ${PORT_WILDFLY}
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
Use StatefulSet to ensure a stable pod name ("iom-0")
add the command "**.devenv-cli.sh iom debug [port]**" to forward the debug port in a background process